### PR TITLE
fix: update aiohttp 3.12.14 → 3.13.3 (resolves 8 security alerts)

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -2,5 +2,5 @@ kopf==1.42.5
 kubernetes==35.0.0
 azure-identity==1.25.1
 azure-mgmt-dns==9.0.0
-aiohttp==3.12.14
+aiohttp==3.13.3
 prometheus_client==0.24.1


### PR DESCRIPTION
## What
Updates aiohttp from 3.12.14 to 3.13.3 to resolve all 8 Dependabot security alerts.

## Security Alerts Resolved
- **#4 (HIGH)**: HTTP Parser zip bomb vulnerability
- **#7-9 (MEDIUM)**: Various aiohttp security issues  
- **#3,5,6,10 (LOW)**: Cookie parser + minor vulnerabilities

## Changes
- `operator/requirements.txt`: aiohttp 3.12.14 → 3.13.3

## Risk
Low — patch version bump, no breaking API changes expected.