### PR TITLE
fix: add gcc build deps for aiohttp 3.13.3 on Alpine

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,10 +1,13 @@
 FROM python:3.14-alpine
 
+RUN apk add --no-cache gcc musl-dev python3-dev
+
 COPY requirements.txt /operator/requirements.txt
 
 WORKDIR /operator
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && apk del gcc musl-dev python3-dev
 
 COPY main.py /operator/main.py
 


### PR DESCRIPTION
## Problem
The Build Test CI pipeline fails because aiohttp 3.13.3 requires C compilation (no prebuilt wheel for Alpine/musl), but the Docker image lacks gcc.

## Fix
Added build dependencies (gcc, musl-dev, python3-dev) before pip install, then removed them after to keep the image small.

## CI
This should fix the Build Test failure since the aiohttp upgrade (PR #47).