### PR TITLE
fix: update kopf 1.42.5 → 1.43.0

### DIFF
--- a/operator/requirements.txt
+++ b/operator/requirements.txt
@@ -1,4 +1,4 @@
-kopf==1.42.5
+kopf==1.43.0
 kubernetes==35.0.0
 azure-identity==1.25.2
 azure-mgmt-dns==9.0.0


### PR DESCRIPTION
Updates kopf to latest version 1.43.0 as flagged by Renovate (Dependency Dashboard #13).