### PR TITLE
fix: copy providers/ directory into container image

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -10,5 +10,6 @@ RUN pip install --no-cache-dir -r requirements.txt \
     && apk del gcc musl-dev python3-dev
 
 COPY main.py /operator/main.py
+COPY providers/ /operator/providers/
 
 CMD ["python", "/operator/main.py"]


### PR DESCRIPTION
## Bug Fix

**Critical:** The Dockerfile only copied `main.py` but not the `providers/` package directory. This means the operator would fail at startup with an `ImportError` when `create_dns_provider()` tries to import from `providers.azure`, `providers.gcp`, or `providers.aws`.

### Changes
- Added `COPY providers/ /operator/providers/` to Dockerfile

### Testing
- Verified the Dockerfile now includes all necessary files
- The CI build test workflow will validate the Docker build succeeds